### PR TITLE
Added support for location binding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ fn impl_glium_vertex_derive(ast: &DeriveInput) -> TokenStream {
         let field_name = &field.ident;
         let vertex_attr_lit = format!("{}", field_name.as_ref().unwrap());
         let mut vertex_attr_name = quote!(#vertex_attr_lit);
+        let mut vertex_location: i32 = -1;
         let mut normalize = false;
 
         for meta in attrs {
@@ -84,6 +85,8 @@ fn impl_glium_vertex_derive(ast: &DeriveInput) -> TokenStream {
 
                     if ident == "attr" {
                         vertex_attr_name = quote!(#lit);
+                    } else if ident == "location" {
+                        vertex_location = format!("{}", quote!(#lit)).parse().unwrap();
                     } else {
                         panic!("Unknown field attribute {}", ident);
                     }
@@ -113,6 +116,7 @@ fn impl_glium_vertex_derive(ast: &DeriveInput) -> TokenStream {
                     };
                     offset
                 },
+                #vertex_location,
                 {
                     fn attr_type_of_val<T: ::glium::vertex::Attribute>(_: &T) -> ::glium::vertex::AttributeType {
                         <T as ::glium::vertex::Attribute>::get_type()


### PR DESCRIPTION
This pull request is related to this pull request: https://github.com/glium/glium/pull/2013

I recently made a pull request for glium that added location bindings. I added this feature to this crate too, in case it gets merged. I never worked with proc-macros before, tell me if I did some oopsies.

Example:
```rust
#[derive(Copy, Clone, Vertex)]
struct Vertex {
    #[glium(location = 0)]
    position: [f32; 2],
    #[glium(attr = "color")]
    color: [f32; 3],
}
```